### PR TITLE
MILAB-6366: gracefully handle samples with zero abundance counts

### DIFF
--- a/.changeset/milab-6366-zero-abundance.md
+++ b/.changeset/milab-6366-zero-abundance.md
@@ -1,0 +1,9 @@
+---
+"@platforma-open/milaboratories.differential-clonotype-abundance.workflow": patch
+"@platforma-open/milaboratories.run-diff-clonotype-abundance-deseq2-r.software": patch
+"@platforma-open/milaboratories.differential-clonotype-abundance.model": patch
+"@platforma-open/milaboratories.differential-clonotype-abundance.ui": patch
+"@platforma-open/milaboratories.differential-clonotype-abundance": patch
+---
+
+MILAB-6366: Gracefully handle samples with zero abundance counts. Previously, selecting a sample that produced no counts upstream caused DESeq2 to crash with `ncol(countData) == nrow(colData) is not TRUE`. Now: empty samples are detected during pre-checks and dropped from the analysis, a per-sample warning is added to the existing errorLogs surface, and the Settings modal shows a dedicated alert listing the samples that will be excluded. If dropping leaves either contrast group with fewer than two replicates, the block stops cleanly with an actionable message instead of letting DESeq2 fail. Applies to both the clonotype and gene/RNA-seq paths.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ software/**/*.sw.json
 software/*.tgz
 .vscode
 .idea
+
+# Python testing toolchain (uv + pytest + ruff)
+.venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -169,6 +169,12 @@ export const platforma = BlockModelV3.create(blockDataModel)
     return ctx.createPFrame(pCols);
   })
 
+  .output('excludedSamples', (ctx) => {
+    const pCols = ctx.outputs?.resolve('excludedSamples')?.getPColumns();
+    if (pCols === undefined) return undefined;
+    return ctx.createPFrame(pCols);
+  })
+
   // Returns a map of results
   .outputWithStatus('pt', (ctx) => {
     const pCols = ctx.outputs?.resolve('topTablePf')?.getPColumns();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7863,7 +7863,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.15
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.15)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.15)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@25.0.9)(rollup@4.55.2)
       typescript: 5.9.3
@@ -7904,7 +7904,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.15
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.15)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.15)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@25.0.9)(rollup@4.55.2)
       typescript: 5.9.3
@@ -13288,7 +13288,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.15)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.15)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3

--- a/software/package.json
+++ b/software/package.json
@@ -5,6 +5,7 @@
   "description": "Block Software: Run DESeq2 with R",
   "scripts": {
     "build": "pl-pkg build",
+    "test": "bash tests/run_tests.sh",
     "prepublishOnly": "pl-pkg prepublish",
     "do-pack": "rm -f *.tgz && pl-pkg build && pnpm pack && mv platforma-open*.tgz package.tgz",
     "changeset": "changeset",

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "differential-clonotype-abundance-software-tests"
+version = "0.0.0"
+description = "Tests for the differential-clonotype-abundance block software components"
+requires-python = ">=3.12"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.6",
+    # Match the prev-checks runtime deps. Keep this in sync with src/prev-checks/requirements.txt.
+    "pandas==2.2.3",
+    "patsy==1.0.1",
+    "numpy==2.2.6",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+extend-select = ["I", "B", "UP", "SIM"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/software/src/deseq2-clonotype/clonotype_deseq2.R
+++ b/software/src/deseq2-clonotype/clonotype_deseq2.R
@@ -149,7 +149,7 @@ if (!(opt$denominator %in% metadata[[opt$contrast_factor]])) {
 # fail later with an opaque message.
 group_sizes <- table(metadata[[opt$contrast_factor]])
 for (lvl in c(opt$numerator, opt$denominator)) {
-  n_lvl <- if (is.na(group_sizes[lvl])) 0 else as.integer(group_sizes[lvl])
+  n_lvl <- if (lvl %in% names(group_sizes)) as.integer(group_sizes[lvl]) else 0L
   if (n_lvl < 2) {
     stop(sprintf(
       "After dropping samples with no counts, group '%s' has %d replicate(s); at least 2 are required.",

--- a/software/src/deseq2-clonotype/clonotype_deseq2.R
+++ b/software/src/deseq2-clonotype/clonotype_deseq2.R
@@ -100,8 +100,32 @@ metadata <- read.table(opt$metadata,
 # This is done by default at the time of reading the metadata in the table
 opt$contrast_factor <- make.names(opt$contrast_factor)
 
-# Filter out samples for which we don't have metadata
-count_long <- count_long[count_long[, "Sample"] %in% rownames(metadata), ]
+# Reconcile samples between count matrix and metadata in BOTH directions.
+# A sample present in metadata but missing from counts (e.g. an upstream block
+# returned zero rows for it) would otherwise produce a count_matrix with fewer
+# columns than metadata has rows, tripping DESeq2's stopifnot.
+samples_in_counts <- unique(as.character(count_long[, "Sample"]))
+samples_in_meta   <- rownames(metadata)
+samples_common    <- intersect(samples_in_meta, samples_in_counts)
+samples_dropped   <- setdiff(samples_in_meta, samples_in_counts)
+samples_extra     <- setdiff(samples_in_counts, samples_in_meta)
+
+if (length(samples_dropped) > 0) {
+  warning(sprintf(
+    "Dropping %d sample(s) from analysis because they have no count rows: %s",
+    length(samples_dropped),
+    paste(samples_dropped, collapse = ", ")
+  ))
+}
+if (length(samples_extra) > 0) {
+  # Pre-existing behaviour: counts-only samples are filtered out silently.
+  count_long <- count_long[count_long[, "Sample"] %in% samples_common, ]
+}
+metadata <- metadata[samples_common, , drop = FALSE]
+
+if (nrow(metadata) == 0) {
+  stop("No samples remain after reconciling count matrix with metadata.")
+}
 
 # Rename some input variables
 values_col <- opt$values_column
@@ -118,6 +142,20 @@ if (!(opt$numerator %in% metadata[[opt$contrast_factor]])) {
 }
 if (!(opt$denominator %in% metadata[[opt$contrast_factor]])) {
   stop("Denominator not found in contrast factor column")
+}
+
+# After dropping empty samples, the numerator/denominator groups may have
+# become too small for DESeq2. Surface a clear error instead of letting DESeq
+# fail later with an opaque message.
+group_sizes <- table(metadata[[opt$contrast_factor]])
+for (lvl in c(opt$numerator, opt$denominator)) {
+  n_lvl <- if (is.na(group_sizes[lvl])) 0 else as.integer(group_sizes[lvl])
+  if (n_lvl < 2) {
+    stop(sprintf(
+      "After dropping samples with no counts, group '%s' has %d replicate(s); at least 2 are required.",
+      lvl, n_lvl
+    ))
+  }
 }
 
 colnames(metadata) <- make.names(colnames(metadata))

--- a/software/src/deseq2-gene/gene_deseq2.R
+++ b/software/src/deseq2-gene/gene_deseq2.R
@@ -153,8 +153,32 @@ metadata <- read.table(opt$metadata,
 # This is done by default at the time of reading the metadata in the table
 opt$contrast_factor <- make.names(opt$contrast_factor)
 
-# Filter out samples for which we don't have metadata
-count_long <- count_long[count_long[, "Sample"] %in% rownames(metadata), ]
+# Reconcile samples between count matrix and metadata in BOTH directions.
+# A sample present in metadata but missing from counts (e.g. an upstream block
+# returned zero rows for it) would otherwise produce a count_matrix with fewer
+# columns than metadata has rows, tripping DESeq2's stopifnot.
+samples_in_counts <- unique(as.character(count_long[, "Sample"]))
+samples_in_meta   <- rownames(metadata)
+samples_common    <- intersect(samples_in_meta, samples_in_counts)
+samples_dropped   <- setdiff(samples_in_meta, samples_in_counts)
+samples_extra     <- setdiff(samples_in_counts, samples_in_meta)
+
+if (length(samples_dropped) > 0) {
+  warning(sprintf(
+    "Dropping %d sample(s) from analysis because they have no count rows: %s",
+    length(samples_dropped),
+    paste(samples_dropped, collapse = ", ")
+  ))
+}
+if (length(samples_extra) > 0) {
+  # Pre-existing behaviour: counts-only samples are filtered out silently.
+  count_long <- count_long[count_long[, "Sample"] %in% samples_common, ]
+}
+metadata <- metadata[samples_common, , drop = FALSE]
+
+if (nrow(metadata) == 0) {
+  stop("No samples remain after reconciling count matrix with metadata.")
+}
 
 # Rename some input variables
 ids_col <- opt$IDs_column
@@ -168,6 +192,20 @@ if (!(opt$numerator %in% metadata[[opt$contrast_factor]])) {
 }
 if (!(opt$denominator %in% metadata[[opt$contrast_factor]])) {
   stop("Denominator not found in contrast factor column")
+}
+
+# After dropping empty samples, the numerator/denominator groups may have
+# become too small for DESeq2. Surface a clear error instead of letting DESeq
+# fail later with an opaque message.
+group_sizes <- table(metadata[[opt$contrast_factor]])
+for (lvl in c(opt$numerator, opt$denominator)) {
+  n_lvl <- if (is.na(group_sizes[lvl])) 0 else as.integer(group_sizes[lvl])
+  if (n_lvl < 2) {
+    stop(sprintf(
+      "After dropping samples with no counts, group '%s' has %d replicate(s); at least 2 are required.",
+      lvl, n_lvl
+    ))
+  }
 }
 
 colnames(metadata) <- make.names(colnames(metadata))

--- a/software/src/deseq2-gene/gene_deseq2.R
+++ b/software/src/deseq2-gene/gene_deseq2.R
@@ -199,7 +199,7 @@ if (!(opt$denominator %in% metadata[[opt$contrast_factor]])) {
 # fail later with an opaque message.
 group_sizes <- table(metadata[[opt$contrast_factor]])
 for (lvl in c(opt$numerator, opt$denominator)) {
-  n_lvl <- if (is.na(group_sizes[lvl])) 0 else as.integer(group_sizes[lvl])
+  n_lvl <- if (lvl %in% names(group_sizes)) as.integer(group_sizes[lvl]) else 0L
   if (n_lvl < 2) {
     stop(sprintf(
       "After dropping samples with no counts, group '%s' has %d replicate(s); at least 2 are required.",

--- a/software/src/prev-checks/prevChecks.py
+++ b/software/src/prev-checks/prevChecks.py
@@ -96,7 +96,15 @@ def main():
     # Replicate-count check on the FILTERED metadata
     contrast_levels = [str(n) for n in numerators] + [str(args.denominator)]
     insufficient = False
-    if args.contrast_factor in filtered_metadata.columns:
+    if args.contrast_factor not in filtered_metadata.columns:
+        # Misconfiguration: the label passed via --contrast_factor doesn't
+        # match any column in metadata. Surface this directly instead of
+        # letting the rank check produce a misleading downstream error.
+        errorLogs.append(
+            f"Error: Contrast factor '{args.contrast_factor}' not found in metadata columns."
+        )
+        insufficient = True
+    else:
         value_counts = filtered_metadata[args.contrast_factor].value_counts()
         for level in contrast_levels:
             n = int(value_counts.get(level, 0))

--- a/software/src/prev-checks/prevChecks.py
+++ b/software/src/prev-checks/prevChecks.py
@@ -1,91 +1,143 @@
+import argparse
+import json
+import os
+
 import numpy as np
 import pandas as pd
 from patsy import dmatrix
-import argparse
-import os
-import json
+
 
 def is_full_rank(design_df, formula):
-    """
-    Checks if the model matrix from the design dataframe is full rank.
-    
-    Parameters:
-    - design_df (pd.DataFrame): Experimental design table with categorical variables.
-    - formula (str): Model formula using R-style syntax (e.g., "~condition + batch").
-    
-    Returns:
-    - bool: True if full rank, False if rank-deficient.
-    """
+    """Checks if the model matrix from the design dataframe is full rank."""
     try:
-        # Generate the design matrix using Patsy
         model_matrix = np.asarray(dmatrix(formula, design_df, return_type="dataframe"))
-
-        # Compute rank
         rank = np.linalg.matrix_rank(model_matrix)
-        
-        # Check if full rank
         return rank == model_matrix.shape[1]
     except Exception as e:
         print(f"Error in model matrix computation: {e}")
         return False
-    
+
+
 def export_result(content, output_dir, filename="continueOrNot.txt"):
-    """ Export QC metrics to a CSV file """
     os.makedirs(output_dir, exist_ok=True)
     output_path = os.path.join(output_dir, filename)
     with open(output_path, "w") as f:
         f.write(content)
 
+
+def _ensure_parent_dir(path):
+    """Make sure the directory containing `path` exists.
+
+    The workflow always writes to the current working directory. A manual
+    invocation with a path in a fresh directory tree would crash the to_csv
+    calls below with FileNotFoundError.
+    """
+    parent = os.path.dirname(path) or "."
+    os.makedirs(parent, exist_ok=True)
+
+
 def main():
-    parser = argparse.ArgumentParser(description='Previous data checks before starting differential analysis.')
-    parser.add_argument('--metadata', type=str, required=True, help='Path to metadata CSV file')
-    parser.add_argument('--output', type=str, required=True, help='Output directory')
-    parser.add_argument('--contrast_factor', type=str, required=True, help='Contrast factor')
-    parser.add_argument('--numerators', required=True, help='Numerators')
-    parser.add_argument('--denominator', type=str, required=True, help='Denominator')
-    parser.add_argument('--error_output', type=str, required=True, help='Error output directory')
+    parser = argparse.ArgumentParser(
+        description="Previous data checks before starting differential analysis."
+    )
+    parser.add_argument("--metadata", type=str, required=True, help="Path to metadata CSV file")
+    parser.add_argument(
+        "--counts",
+        type=str,
+        required=True,
+        help="Path to counts CSV (long format with Sample column)",
+    )
+    parser.add_argument("--output", type=str, required=True, help="Output directory")
+    parser.add_argument("--contrast_factor", type=str, required=True, help="Contrast factor")
+    parser.add_argument("--numerators", required=True, help="Numerators")
+    parser.add_argument("--denominator", type=str, required=True, help="Denominator")
+    parser.add_argument("--error_output", type=str, required=True, help="Error log CSV output path")
+    parser.add_argument(
+        "--excluded_samples_output",
+        type=str,
+        required=True,
+        help="Excluded samples CSV output path",
+    )
+    parser.add_argument(
+        "--filtered_covariates_output",
+        type=str,
+        required=True,
+        help="Filtered covariates CSV output path",
+    )
     args = parser.parse_args()
 
-    # Convert numerators json to list
     numerators = json.loads(args.numerators)
 
     # Load metadata
     metadata = pd.read_csv(args.metadata, dtype=str)
-    # Set sample as index
     metadata.set_index(keys="Sample", inplace=True)
-    # Create error logs table
-    df_error = pd.DataFrame(columns=["Error", "value"])
+
+    # Read only the Sample column from counts — cheap even for huge files.
+    # Materialise as a set so the membership checks below are O(1) instead of
+    # O(len(counts_samples)) per metadata sample.
+    counts_samples = set(pd.read_csv(args.counts, usecols=["Sample"], dtype=str)["Sample"].unique())
+
+    metadata_samples = list(metadata.index)
+    dropped = [s for s in metadata_samples if s not in counts_samples]
+
     errorLogs = []
-    # Make sure we have enough replicates for all the comparisons that are going be done
-    for numerator in numerators:
-        # Make sure at least we have a sample with enough replicates
-        if int(metadata[args.contrast_factor].value_counts()[[str(numerator), str(args.denominator)]].max()) == 1:
-            errorLogs.append(f"Warning: This block requires replicates to perform the analysis. It is not feasible to compare {numerator} vs {args.denominator} because there is only one sample for each condition.")
-            
-    if len(errorLogs) > 0:
+    excluded_rows = []
+
+    for s in dropped:
+        # Include the sample name in the reason so the UI's getUniqueValues
+        # call (which deduplicates) still yields one entry per excluded sample.
+        excluded_rows.append({"Sample": s, "reason": f"Sample '{s}' has no abundance counts"})
+        errorLogs.append(
+            f"Warning: Sample '{s}' has no abundance counts and was excluded from the analysis."
+        )
+
+    filtered_metadata = metadata.loc[[s for s in metadata_samples if s in counts_samples]]
+
+    # Replicate-count check on the FILTERED metadata
+    contrast_levels = [str(n) for n in numerators] + [str(args.denominator)]
+    insufficient = False
+    if args.contrast_factor in filtered_metadata.columns:
+        value_counts = filtered_metadata[args.contrast_factor].value_counts()
+        for level in contrast_levels:
+            n = int(value_counts.get(level, 0))
+            if n < 2:
+                errorLogs.append(
+                    f"Warning: Group '{level}' has {n} sample(s) after dropping samples without counts; at least 2 are required."
+                )
+                insufficient = True
+
+    if insufficient:
         export_result("stop", args.output)
     else:
-         # Rename columns to numbers toa void issues related to weird characters
-        metadata.columns = [f"c{i}" for i in range(len(metadata.columns))]
-        # Get formula
-        formula = "~" + " + ".join(metadata.columns)
-        # Check if the design matrix is full rank
-        rankResult = is_full_rank(metadata, formula)
-
-        # Write result to file
-        if rankResult:
+        # Rename columns to numbers so patsy doesn't choke on punctuation
+        # or whitespace in metadata column names.
+        rank_metadata = filtered_metadata.copy()
+        rank_metadata.columns = [f"c{i}" for i in range(len(rank_metadata.columns))]
+        formula = "~" + " + ".join(rank_metadata.columns)
+        if is_full_rank(rank_metadata, formula):
             export_result("continue", args.output)
         else:
-            errorLogs.append("Warning: The model matrix is not full rank, so the model cannot be fit as specified. \
-              One or more variables or interaction terms in the design formula are linear\
-              combinations of the others and must be removed. Please, check the metadata \
-              columns included in the Design section.")
+            errorLogs.append(
+                "Warning: The model matrix is not full rank, so the model cannot be fit as specified. "
+                "One or more variables or interaction terms in the design formula are linear "
+                "combinations of the others and must be removed. Please, check the metadata "
+                "columns included in the Design section."
+            )
             export_result("stop", args.output)
 
-    # output error logs table
-    df_error['Error'] = range(len(errorLogs))
-    df_error['value'] = errorLogs
+    _ensure_parent_dir(args.error_output)
+    df_error = pd.DataFrame({"Error": range(len(errorLogs)), "value": errorLogs})
     df_error.to_csv(args.error_output, index=False)
+
+    # Write excluded samples CSV — always exists, even if empty
+    _ensure_parent_dir(args.excluded_samples_output)
+    df_excluded = pd.DataFrame(excluded_rows, columns=["Sample", "reason"])
+    df_excluded.to_csv(args.excluded_samples_output, index=False)
+
+    # Write filtered covariates CSV (with Sample as a column, matching input format)
+    _ensure_parent_dir(args.filtered_covariates_output)
+    filtered_metadata.reset_index().to_csv(args.filtered_covariates_output, index=False)
+
 
 if __name__ == "__main__":
     main()

--- a/software/tests/run_tests.sh
+++ b/software/tests/run_tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOFTWARE_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+# --- R smoke tests for the DESeq2 scripts ---
+if command -v Rscript >/dev/null 2>&1; then
+  Rscript "$SCRIPT_DIR/zero_sample_test.R"
+else
+  echo "SKIP: Rscript not installed; R smoke tests skipped."
+fi
+
+# --- Python tests for prevChecks.py ---
+if command -v uv >/dev/null 2>&1; then
+  cd "$SOFTWARE_DIR"
+  uv run --quiet pytest tests/ -v
+else
+  echo "SKIP: uv not installed; Python tests skipped."
+fi

--- a/software/tests/test_prev_checks.py
+++ b/software/tests/test_prev_checks.py
@@ -255,6 +255,32 @@ class TestMultipleNumerators:
         assert any("'C'" in v and "at least 2 are required" in v for v in res["errors"]["value"])
 
 
+class TestContrastFactorMissing:
+    """The Tengo workflow passes the contrast-factor label from the PColumn
+    spec, which is normally a column header in the metadata CSV. If the label
+    doesn't match (misconfiguration), the script must stop with a clear,
+    pointed error — not silently fall through to a misleading rank-deficiency
+    message downstream."""
+
+    # Without this guard, rank check ran instead and produced a confusing
+    # "not full rank" warning that didn't name the actual problem.
+    def test_stops_with_named_contrast_factor_error(self, tmp_path):
+        # Metadata has Group + Batch, but workflow asks for "Treatment"
+        meta = pd.DataFrame(
+            {
+                "Sample": ["S1", "S2", "S3", "S4"],
+                "Group": ["A", "B", "A", "B"],
+                "Batch": ["b1", "b2", "b1", "b2"],
+            }
+        )
+        counts = _counts(["S1", "S2", "S3", "S4"])
+
+        res = _run_script(tmp_path, meta, counts, "Treatment", ["A"], "B")
+
+        assert res["continue_or_not"] == "stop"
+        assert any("Treatment" in v and "not found" in v for v in res["errors"]["value"])
+
+
 class TestOutputFileShape:
     """Both auxiliary outputs must always exist with the expected columns,
     even on the happy path. Schema stability matters for the downstream

--- a/software/tests/test_prev_checks.py
+++ b/software/tests/test_prev_checks.py
@@ -1,0 +1,336 @@
+"""Behavioral tests for prevChecks.py.
+
+Invokes the script as a subprocess (the script lives in `src/prev-checks/`,
+a directory whose name contains a hyphen — not importable as a Python
+package). Each test constructs synthetic metadata + counts CSVs in a
+`tmp_path`, runs the script, and asserts on the four output files
+(continueOrNot.txt, errorLogs.csv, excludedSamples.csv,
+filteredCovariates.csv).
+
+Run from `software/`:
+    uv sync
+    uv run pytest tests/
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+SCRIPT = Path(__file__).resolve().parent.parent / "src" / "prev-checks" / "prevChecks.py"
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / helpers                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _run_script(
+    workdir: Path,
+    metadata: pd.DataFrame,
+    counts: pd.DataFrame,
+    contrast_factor: str,
+    numerators: list[str],
+    denominator: str,
+) -> dict:
+    """Run prevChecks.py with the given inputs and collect all four outputs."""
+    metadata_path = workdir / "covariates.csv"
+    counts_path = workdir / "rawCounts.csv"
+    metadata.to_csv(metadata_path, index=False)
+    counts.to_csv(counts_path, index=False)
+
+    error_path = workdir / "errorLogs.csv"
+    excluded_path = workdir / "excludedSamples.csv"
+    filtered_path = workdir / "filteredCovariates.csv"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--metadata",
+            str(metadata_path),
+            "--counts",
+            str(counts_path),
+            "--output",
+            str(workdir),
+            "--contrast_factor",
+            contrast_factor,
+            "--numerators",
+            json.dumps(numerators),
+            "--denominator",
+            denominator,
+            "--error_output",
+            str(error_path),
+            "--excluded_samples_output",
+            str(excluded_path),
+            "--filtered_covariates_output",
+            str(filtered_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    continue_or_not = (workdir / "continueOrNot.txt").read_text().strip()
+    return {
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "continue_or_not": continue_or_not,
+        "errors": pd.read_csv(error_path) if error_path.exists() else pd.DataFrame(),
+        "excluded": pd.read_csv(excluded_path) if excluded_path.exists() else pd.DataFrame(),
+        "filtered_meta": pd.read_csv(filtered_path) if filtered_path.exists() else pd.DataFrame(),
+    }
+
+
+def _metadata(samples: list[str], groups: list[str], **extra: list) -> pd.DataFrame:
+    """Build a minimal metadata table — Sample + Group, plus optional extras."""
+    return pd.DataFrame({"Sample": samples, "Group": groups, **extra})
+
+
+def _counts(samples: list[str], n_per_sample: int = 3) -> pd.DataFrame:
+    """Long-format counts: n_per_sample rows per sample, varied values."""
+    rows = [
+        {"Sample": s, "Clonotype key": f"c{i}", "Number of UMIs": 10 + i}
+        for s in samples
+        for i in range(n_per_sample)
+    ]
+    return pd.DataFrame(rows, columns=["Sample", "Clonotype key", "Number of UMIs"])
+
+
+# --------------------------------------------------------------------------- #
+# Behavioral tests                                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestNoSamplesDropped:
+    """Baseline path — every metadata sample has counts."""
+
+    # If reconciliation gets too aggressive, every healthy block run fails —
+    # this guard catches that regression.
+    def test_continues_when_all_samples_present(self, tmp_path):
+        meta = _metadata(["S1", "S2", "S3", "S4"], ["A", "B", "A", "B"])
+        counts = _counts(["S1", "S2", "S3", "S4"])
+
+        res = _run_script(tmp_path, meta, counts, "Group", ["A"], "B")
+
+        assert res["continue_or_not"] == "continue"
+        assert len(res["excluded"]) == 0
+        assert list(res["excluded"].columns) == ["Sample", "reason"]
+        # Filtered covariates should match input one-for-one
+        assert set(res["filtered_meta"]["Sample"]) == {"S1", "S2", "S3", "S4"}
+        # No warnings emitted
+        assert len(res["errors"]) == 0
+        assert list(res["errors"].columns) == ["Error", "value"]
+
+
+class TestOneSampleDropped:
+    """One metadata sample absent from counts; groups remain viable."""
+
+    # Confirms the symmetric reconciliation excludes the right sample, emits
+    # one warning per dropped sample, and names the sample in the reason text
+    # (so the UI's getUniqueValues call doesn't collapse multiple drops to one).
+    def test_reports_dropped_sample(self, tmp_path):
+        meta = _metadata(
+            ["S1", "S2", "S3", "S4", "S5", "S6"],
+            ["A", "A", "A", "B", "B", "B"],
+        )
+        counts = _counts(["S1", "S2", "S4", "S5", "S6"])  # S3 absent
+
+        res = _run_script(tmp_path, meta, counts, "Group", ["A"], "B")
+
+        assert res["continue_or_not"] == "continue"
+        assert list(res["excluded"]["Sample"]) == ["S3"]
+        assert "S3" in res["excluded"]["reason"].iloc[0]
+        assert set(res["filtered_meta"]["Sample"]) == {"S1", "S2", "S4", "S5", "S6"}
+        # Filtered covariates preserves Group column values
+        assert set(res["filtered_meta"]["Group"]) == {"A", "B"}
+        # One per-sample warning, no group warnings (groups still ≥ 2)
+        assert len(res["errors"]) == 1
+        assert "S3" in res["errors"]["value"].iloc[0]
+
+    # Two samples missing from the same group, but the group still has ≥2
+    # replicates — both should be listed in excludedSamples with distinct
+    # reason text (sample name in each row).
+    def test_two_samples_dropped_listed_separately(self, tmp_path):
+        meta = _metadata(
+            ["S1", "S2", "S3", "S4", "S5", "S6", "S7"],
+            ["A", "A", "A", "A", "A", "B", "B"],
+        )
+        # Drop S3 and S5; group A still has 3 (S1, S2, S4), B has 2
+        counts = _counts(["S1", "S2", "S4", "S6", "S7"])
+
+        res = _run_script(tmp_path, meta, counts, "Group", ["A"], "B")
+
+        assert res["continue_or_not"] == "continue"
+        assert set(res["excluded"]["Sample"]) == {"S3", "S5"}
+        # Each row's reason text contains its own sample name
+        for _, row in res["excluded"].iterrows():
+            assert row["Sample"] in row["reason"]
+
+
+class TestGroupTooSmall:
+    """Dropping the empty sample leaves a contrast group with <2 replicates."""
+
+    # Guards against shipping a config that DESeq2 would reject — but with a
+    # clearer, group-specific message that names the actual problem so the
+    # user can fix their sample selection rather than reading R stack traces.
+    def test_stops_with_actionable_message(self, tmp_path):
+        meta = _metadata(["S1", "S2", "S3", "S4"], ["A", "B", "A", "B"])
+        counts = _counts(["S1", "S2", "S4"])  # S3 absent → A drops to 1
+
+        res = _run_script(tmp_path, meta, counts, "Group", ["A"], "B")
+
+        assert res["continue_or_not"] == "stop"
+        # Two errorLogs entries: per-sample warning + group-size warning
+        assert len(res["errors"]) == 2
+        assert any("S3" in v for v in res["errors"]["value"])
+        assert any("'A'" in v and "at least 2 are required" in v for v in res["errors"]["value"])
+        assert list(res["excluded"]["Sample"]) == ["S3"]
+
+
+class TestRankDeficientDesign:
+    """When filtered metadata has a non-full-rank design, stop with rank warning."""
+
+    # Group and Subgroup are perfectly collinear (every A is X, every B is Y),
+    # so the design matrix is rank-deficient. The rank check should fire even
+    # though no samples were dropped.
+    def test_stops_on_rank_deficient(self, tmp_path):
+        meta = _metadata(
+            ["S1", "S2", "S3", "S4"],
+            ["A", "B", "A", "B"],
+            Subgroup=["X", "Y", "X", "Y"],
+        )
+        counts = _counts(["S1", "S2", "S3", "S4"])
+
+        res = _run_script(tmp_path, meta, counts, "Group", ["A"], "B")
+
+        assert res["continue_or_not"] == "stop"
+        assert any("not full rank" in v for v in res["errors"]["value"])
+        assert len(res["excluded"]) == 0
+
+
+class TestEmptyCounts:
+    """Edge case: counts CSV has the header only — no data rows."""
+
+    # Surfaces a real downstream scenario (every upstream sample produced
+    # zero rows). All metadata samples should be excluded; both groups go
+    # to zero replicates → stop with per-group warnings.
+    def test_excludes_all_samples_and_stops(self, tmp_path):
+        meta = _metadata(["S1", "S2", "S3", "S4"], ["A", "B", "A", "B"])
+        counts = pd.DataFrame(columns=["Sample", "Clonotype key", "Number of UMIs"])
+
+        res = _run_script(tmp_path, meta, counts, "Group", ["A"], "B")
+
+        assert res["continue_or_not"] == "stop"
+        assert set(res["excluded"]["Sample"]) == {"S1", "S2", "S3", "S4"}
+        # 4 per-sample warnings + at least 2 group warnings (A, B both empty)
+        assert len(res["errors"]) >= 4
+        assert any("'A'" in v and "0 sample(s)" in v for v in res["errors"]["value"])
+        assert any("'B'" in v and "0 sample(s)" in v for v in res["errors"]["value"])
+        # Filtered covariates is empty
+        assert len(res["filtered_meta"]) == 0
+
+
+class TestMultipleNumerators:
+    """Multiple numerators in one run — replicate check applies to each level."""
+
+    # The block lets users pick multiple numerators against one denominator.
+    # Each numerator level must have ≥2 replicates independently — if even
+    # one fails, the whole run stops.
+    def test_one_undersized_numerator_triggers_stop(self, tmp_path):
+        meta = _metadata(
+            ["S1", "S2", "S3", "S4", "S5"],
+            ["A", "A", "B", "B", "C"],  # C has only 1 replicate
+        )
+        counts = _counts(["S1", "S2", "S3", "S4", "S5"])
+
+        # User asks: A vs B (ok) AND C vs B (C undersized)
+        res = _run_script(tmp_path, meta, counts, "Group", ["A", "C"], "B")
+
+        assert res["continue_or_not"] == "stop"
+        assert any("'C'" in v and "at least 2 are required" in v for v in res["errors"]["value"])
+
+
+class TestOutputFileShape:
+    """Both auxiliary outputs must always exist with the expected columns,
+    even on the happy path. Schema stability matters for the downstream
+    PColumn import — a missing column would crash the workflow."""
+
+    # excludedSamples.csv and errorLogs.csv must have their header rows even
+    # when they contain no data — the workflow's xsv.importFile would fail
+    # otherwise.
+    def test_schemas_present_even_when_empty(self, tmp_path):
+        meta = _metadata(["S1", "S2"], ["A", "B"])
+        counts = _counts(["S1", "S2"])
+
+        res = _run_script(tmp_path, meta, counts, "Group", ["A"], "B")
+
+        # Schemas
+        assert list(res["excluded"].columns) == ["Sample", "reason"]
+        assert list(res["errors"].columns) == ["Error", "value"]
+        # filteredCovariates preserves the input metadata columns
+        assert "Sample" in res["filtered_meta"].columns
+        assert "Group" in res["filtered_meta"].columns
+
+    # Without explicit dtype, pandas coerces numeric sample IDs to int,
+    # breaking string-comparison with axis keys downstream. Verify they
+    # round-trip as strings.
+    def test_numeric_sample_ids_stay_strings(self, tmp_path):
+        meta = _metadata(["123", "456", "789", "012"], ["A", "B", "A", "B"])
+        counts = _counts(["123", "456", "789", "012"])
+
+        res = _run_script(tmp_path, meta, counts, "Group", ["A"], "B")
+
+        assert res["continue_or_not"] == "continue"
+        # Pandas may read these IDs as ints in the test, but the script treats
+        # them as strings for set membership: no samples reported as dropped.
+        assert len(res["excluded"]) == 0
+
+    # Manual invocations may place outputs in a fresh directory subtree;
+    # the script must auto-create the parents. Regression guard for
+    # _ensure_parent_dir().
+    def test_creates_missing_output_directories(self, tmp_path):
+        meta = _metadata(["S1", "S2"], ["A", "B"])
+        counts = _counts(["S1", "S2"])
+
+        meta.to_csv(tmp_path / "covariates.csv", index=False)
+        counts.to_csv(tmp_path / "rawCounts.csv", index=False)
+
+        # Outputs land in subdirs that don't exist yet
+        outdir = tmp_path / "nested" / "outputs"
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--metadata",
+                str(tmp_path / "covariates.csv"),
+                "--counts",
+                str(tmp_path / "rawCounts.csv"),
+                "--output",
+                str(outdir),
+                "--contrast_factor",
+                "Group",
+                "--numerators",
+                json.dumps(["A"]),
+                "--denominator",
+                "B",
+                "--error_output",
+                str(outdir / "errorLogs.csv"),
+                "--excluded_samples_output",
+                str(outdir / "excludedSamples.csv"),
+                "--filtered_covariates_output",
+                str(outdir / "filteredCovariates.csv"),
+            ],
+            check=True,
+        )
+
+        # All four outputs landed in the previously-nonexistent directory
+        assert (outdir / "continueOrNot.txt").exists()
+        assert (outdir / "errorLogs.csv").exists()
+        assert (outdir / "excludedSamples.csv").exists()
+        assert (outdir / "filteredCovariates.csv").exists()

--- a/software/tests/zero_sample_test.R
+++ b/software/tests/zero_sample_test.R
@@ -1,0 +1,233 @@
+#!/usr/bin/env Rscript
+# Smoke tests for clonotype_deseq2.R and gene_deseq2.R sample reconciliation.
+# Skips cleanly when DESeq2 (and its deps) aren't available locally.
+
+if (!requireNamespace("DESeq2", quietly = TRUE) ||
+    !requireNamespace("tidyr", quietly = TRUE) ||
+    !requireNamespace("dplyr", quietly = TRUE) ||
+    !requireNamespace("optparse", quietly = TRUE)) {
+  cat("SKIP: DESeq2 (or one of optparse/tidyr/dplyr) is not installed locally; test skipped.\n")
+  quit(status = 0)
+}
+
+`%||%` <- function(a, b) if (is.null(a)) b else a
+
+SCRIPT_DIR <- (function() {
+  # Try a few ways to locate this script — different shells/Rscript invocations
+  # expose slightly different things.
+  args <- commandArgs(trailingOnly = FALSE)
+  file_arg <- grep("--file=", args, value = TRUE)
+  if (length(file_arg) > 0) {
+    return(normalizePath(dirname(sub("--file=", "", file_arg[1]))))
+  }
+  cwd <- normalizePath(getwd())
+  if (basename(cwd) == "tests") return(cwd)
+  if (basename(cwd) == "software") return(normalizePath(file.path(cwd, "tests")))
+  return(cwd)
+})()
+
+CLONOTYPE_SCRIPT <- normalizePath(file.path(SCRIPT_DIR, "..", "src", "deseq2-clonotype", "clonotype_deseq2.R"))
+GENE_SCRIPT      <- normalizePath(file.path(SCRIPT_DIR, "..", "src", "deseq2-gene", "gene_deseq2.R"))
+
+# --- Fixture helpers ----------------------------------------------------------
+
+write_long_counts <- function(path, samples, ids, id_col, value_col, value_fn) {
+  # Build long-format counts CSV — one row per (sample, id) with value > 0
+  rows <- list()
+  for (s in samples) {
+    for (cl in ids) {  # cl, not c — avoid shadowing base R c()
+      v <- value_fn(s, cl)
+      if (v > 0) {
+        rows[[length(rows) + 1L]] <- setNames(
+          list(s, cl, v),
+          c("Sample", id_col, value_col)
+        )
+      }
+    }
+  }
+  df <- do.call(rbind, lapply(rows, as.data.frame, stringsAsFactors = FALSE, check.names = FALSE))
+  if (is.null(df)) {
+    # No rows — emit header only
+    df <- data.frame(
+      Sample = character(),
+      x = character(),
+      y = integer(),
+      check.names = FALSE,
+      stringsAsFactors = FALSE
+    )
+    names(df) <- c("Sample", id_col, value_col)
+  }
+  write.csv(df, path, row.names = FALSE)
+}
+
+write_metadata <- function(path, samples, groups) {
+  m <- data.frame(Sample = samples, Group = groups,
+                  check.names = FALSE, stringsAsFactors = FALSE)
+  write.csv(m, path, row.names = FALSE)
+}
+
+run_clonotype <- function(wd) {
+  cmd <- sprintf(
+    "cd %s && Rscript %s -c rawCounts.csv -m covariates.csv -t Group -n A -d B -o topTable.csv --IDs_column 'Clonotype key' --values_column 'Number of UMIs' --min_counts 1 --fraction_for_filter 0.01 2>&1",
+    shQuote(wd), shQuote(CLONOTYPE_SCRIPT)
+  )
+  out <- suppressWarnings(system(cmd, intern = TRUE))
+  list(status = attr(out, "status") %||% 0, output = paste(out, collapse = "\n"))
+}
+
+run_gene <- function(wd) {
+  cmd <- sprintf(
+    "cd %s && Rscript %s -c rawCounts.csv -m covariates.csv -t Group -n A -d B -o topTable.csv --IDs_column 'Ensembl Id' -s test-species 2>&1",
+    shQuote(wd), shQuote(GENE_SCRIPT)
+  )
+  out <- suppressWarnings(system(cmd, intern = TRUE))
+  list(status = attr(out, "status") %||% 0, output = paste(out, collapse = "\n"))
+}
+
+assert_pass <- function(name, cond, msg = "") {
+  if (!isTRUE(cond)) {
+    cat(sprintf("FAIL [%s]: %s\n", name, msg))
+    quit(status = 1)
+  }
+}
+
+# --- Scenario 1: clonotype, drop a sample but groups stay ≥2 ------------------
+# Why: covers the happy path of the reconciliation — the previously crashing
+# case (sample in metadata, absent from counts) now succeeds because the empty
+# sample is dropped and the remaining group sizes still satisfy DESeq2.
+cat("\n=== Scenario 1: clonotype, drop one sample, groups still ≥ 2 ===\n")
+wd1 <- tempfile("dca-clonotype-drop-")
+dir.create(wd1)
+write_long_counts(
+  file.path(wd1, "rawCounts.csv"),
+  samples = c("S1", "S2", "S4", "S5", "S6"),  # S3 absent from counts
+  ids = c("c1", "c2", "c3", "c4", "c5"),
+  id_col = "Clonotype key",
+  value_col = "Number of UMIs",
+  value_fn = function(s, cl) {
+    base <- switch(s, "S1" = 10, "S2" = 50, "S4" = 30, "S5" = 22, "S6" = 41)
+    base + nchar(cl)
+  }
+)
+# Metadata lists 6 samples; groups A=3 (S1,S2,S3), B=3 (S4,S5,S6).
+# Dropping S3 leaves A=2, B=3 — analysis still viable.
+write_metadata(
+  file.path(wd1, "covariates.csv"),
+  samples = c("S1", "S2", "S3", "S4", "S5", "S6"),
+  groups  = c("A",  "A",  "A",  "B",  "B",  "B")
+)
+res1 <- run_clonotype(wd1)
+cat(res1$output, "\n")
+assert_pass("S1-exit", res1$status == 0,
+            sprintf("clonotype run exited %d, expected 0", res1$status))
+assert_pass("S1-warn", grepl("no count rows", res1$output, fixed = TRUE),
+            "expected 'no count rows' warning not found")
+assert_pass("S1-warn-names-sample", grepl("S3", res1$output, fixed = TRUE),
+            "warning text should name the dropped sample 'S3'")
+assert_pass("S1-toptable", file.exists(file.path(wd1, "topTable.csv")),
+            "topTable.csv should have been produced")
+cat("PASS: Scenario 1 — clonotype drop, groups still viable\n")
+
+# --- Scenario 2: clonotype, baseline (no drops) -------------------------------
+# Why: false-positive guard — the warning must not fire when all samples have
+# counts. Catches regressions where the reconciliation gets too aggressive.
+cat("\n=== Scenario 2: clonotype, baseline (no drops) ===\n")
+wd2 <- tempfile("dca-clonotype-baseline-")
+dir.create(wd2)
+write_long_counts(
+  file.path(wd2, "rawCounts.csv"),
+  samples = c("S1", "S2", "S3", "S4"),
+  ids = c("c1", "c2", "c3", "c4", "c5"),
+  id_col = "Clonotype key",
+  value_col = "Number of UMIs",
+  value_fn = function(s, cl) {
+    base <- switch(s, "S1" = 10, "S2" = 50, "S3" = 12, "S4" = 30)
+    base + nchar(cl)
+  }
+)
+write_metadata(
+  file.path(wd2, "covariates.csv"),
+  samples = c("S1", "S2", "S3", "S4"),
+  groups  = c("A",  "B",  "A",  "B")
+)
+res2 <- run_clonotype(wd2)
+cat(res2$output, "\n")
+assert_pass("S2-exit", res2$status == 0,
+            sprintf("baseline run exited %d, expected 0", res2$status))
+assert_pass("S2-no-warn", !grepl("no count rows", res2$output, fixed = TRUE),
+            "baseline must not emit 'no count rows' warning")
+assert_pass("S2-toptable", file.exists(file.path(wd2, "topTable.csv")),
+            "baseline must produce topTable.csv")
+cat("PASS: Scenario 2 — clonotype baseline, no false-positive warning\n")
+
+# --- Scenario 3: clonotype, dropping makes group too small --------------------
+# Why: dropping an empty sample can leave a contrast group with <2 replicates.
+# The new guard must stop with a clear, group-specific error before DESeq2
+# fails with its opaque stopifnot message.
+cat("\n=== Scenario 3: clonotype, dropping leaves group with <2 replicates ===\n")
+wd3 <- tempfile("dca-clonotype-toosmall-")
+dir.create(wd3)
+write_long_counts(
+  file.path(wd3, "rawCounts.csv"),
+  samples = c("S1", "S2", "S4"),  # S3 absent — and S3 is in group A
+  ids = c("c1", "c2", "c3", "c4", "c5"),
+  id_col = "Clonotype key",
+  value_col = "Number of UMIs",
+  value_fn = function(s, cl) {
+    base <- switch(s, "S1" = 10, "S2" = 50, "S4" = 30)
+    base + nchar(cl)
+  }
+)
+# A has S1, S3 (S3 absent → A drops to 1). B has S2, S4 (both present, =2).
+write_metadata(
+  file.path(wd3, "covariates.csv"),
+  samples = c("S1", "S2", "S3", "S4"),
+  groups  = c("A",  "B",  "A",  "B")
+)
+res3 <- run_clonotype(wd3)
+cat(res3$output, "\n")
+assert_pass("S3-exit", res3$status != 0,
+            "expected non-zero exit when group too small")
+assert_pass("S3-msg", grepl("at least 2 are required", res3$output, fixed = TRUE),
+            "expected actionable 'at least 2 are required' message")
+assert_pass("S3-msg-names-group", grepl("group 'A'", res3$output, fixed = TRUE),
+            "error should name the undersized group 'A'")
+assert_pass("S3-no-toptable", !file.exists(file.path(wd3, "topTable.csv")),
+            "topTable.csv must NOT be produced when guard fires")
+cat("PASS: Scenario 3 — group-too-small guard fires with clear message\n")
+
+# --- Scenario 4: gene_deseq2.R covers the same reconciliation -----------------
+# Why: gene_deseq2.R applies the identical fix to the RNA-seq path. Without
+# this scenario, gene-script regressions slip through.
+cat("\n=== Scenario 4: gene, drop one sample, groups still ≥ 2 ===\n")
+wd4 <- tempfile("dca-gene-drop-")
+dir.create(wd4)
+write_long_counts(
+  file.path(wd4, "rawCounts.csv"),
+  samples = c("S1", "S2", "S4", "S5", "S6"),  # S3 absent
+  ids = c("g1", "g2", "g3", "g4", "g5"),
+  id_col = "Ensembl Id",
+  value_col = "Raw gene expression",
+  value_fn = function(s, cl) {
+    base <- switch(s, "S1" = 100, "S2" = 200, "S4" = 150, "S5" = 180, "S6" = 220)
+    base + nchar(cl) * 10
+  }
+)
+write_metadata(
+  file.path(wd4, "covariates.csv"),
+  samples = c("S1", "S2", "S3", "S4", "S5", "S6"),
+  groups  = c("A",  "A",  "A",  "B",  "B",  "B")
+)
+res4 <- run_gene(wd4)
+cat(res4$output, "\n")
+assert_pass("S4-exit", res4$status == 0,
+            sprintf("gene run exited %d, expected 0", res4$status))
+assert_pass("S4-warn", grepl("no count rows", res4$output, fixed = TRUE),
+            "expected 'no count rows' warning in gene script too")
+assert_pass("S4-warn-names-sample", grepl("S3", res4$output, fixed = TRUE),
+            "gene warning should name the dropped sample 'S3'")
+assert_pass("S4-toptable", file.exists(file.path(wd4, "topTable.csv")),
+            "gene script should produce topTable.csv")
+cat("PASS: Scenario 4 — gene script drop, groups still viable\n")
+
+cat("\nAll scenarios passed.\n")

--- a/software/uv.lock
+++ b/software/uv.lock
@@ -1,0 +1,337 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
+    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
+    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
+    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[[package]]
+name = "differential-clonotype-abundance-software-tests"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "numpy", specifier = "==2.2.6" },
+    { name = "pandas", specifier = "==2.2.3" },
+    { name = "patsy", specifier = "==1.0.1" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "ruff", specifier = ">=0.6" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
+    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
+    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b1d432e8d08679a40e2a6d8b2f9770a5c21793a6f9f47fdd52c5ce1948a5a8a9", size = 12529893, upload-time = "2024-09-20T13:09:09.655Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5a1595fe639f5988ba6a8e5bc9649af3baf26df3998a0abe56c02609392e0a4", size = 11363475, upload-time = "2024-09-20T13:09:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/4bba3f03f7d07207481fed47f5b35f556c7441acddc368ec43d6643c5777/pandas-2.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5de54125a92bb4d1c051c0659e6fcb75256bf799a732a87184e5ea503965bce3", size = 15188645, upload-time = "2024-09-20T19:02:03.88Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb8ae78d8af97f849404f21411c95062db1496aeb3e56f146f0355c9989319", size = 12739445, upload-time = "2024-09-20T13:09:17.621Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e8/45a05d9c39d2cea61ab175dbe6a2de1d05b679e8de2011da4ee190d7e748/pandas-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dfcb5ee8d4d50c06a51c2fffa6cff6272098ad6540aed1a76d15fb9318194d8", size = 16359235, upload-time = "2024-09-20T19:02:07.094Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/99/617d07a6a5e429ff90c90da64d428516605a1ec7d7bea494235e1c3882de/pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a", size = 14056756, upload-time = "2024-09-20T13:09:20.474Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d4/1244ab8edf173a10fd601f7e13b9566c1b525c4f365d6bee918e68381889/pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13", size = 11504248, upload-time = "2024-09-20T13:09:23.137Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/3b8f4e0ed70644e85cfdcd57454686b9057c6c38d2f74fe4b8bc2527214a/pandas-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f00d1345d84d8c86a63e476bb4955e46458b304b9575dcf71102b5c705320015", size = 12477643, upload-time = "2024-09-20T13:09:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/93/b3f5d1838500e22c8d793625da672f3eec046b1a99257666c94446969282/pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3508d914817e153ad359d7e069d752cdd736a247c322d932eb89e6bc84217f28", size = 11281573, upload-time = "2024-09-20T13:09:28.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/94/6c79b07f0e5aab1dcfa35a75f4817f5c4f677931d4234afcd75f0e6a66ca/pandas-2.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22a9d949bfc9a502d320aa04e5d02feab689d61da4e7764b62c30b991c42c5f0", size = 15196085, upload-time = "2024-09-20T19:02:10.451Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/aa8da88ca0eadbabd0a639788a6da13bb2ff6edbbb9f29aa786450a30a91/pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a255b2c19987fbbe62a9dfd6cff7ff2aa9ccab3fc75218fd4b7530f01efa24", size = 12711809, upload-time = "2024-09-20T13:09:30.814Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7c/c6dbdb0cb2a4344cacfb8de1c5808ca885b2e4dcfde8008266608f9372af/pandas-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:800250ecdadb6d9c78eae4990da62743b857b470883fa27f652db8bdde7f6659", size = 16356316, upload-time = "2024-09-20T19:02:13.825Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b7/8b757e7d92023b832869fa8881a992696a0bfe2e26f72c9ae9f255988d42/pandas-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6374c452ff3ec675a8f46fd9ab25c4ad0ba590b71cf0656f8b6daa5202bca3fb", size = 14022055, upload-time = "2024-09-20T13:09:33.462Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/bc/4b18e2b8c002572c5a441a64826252ce5da2aa738855747247a971988043/pandas-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:61c5ad4043f791b61dd4752191d9f07f0ae412515d59ba8f005832a532f8736d", size = 11481175, upload-time = "2024-09-20T13:09:35.871Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/a5d88146815e972d40d19247b2c162e88213ef51c7c25993942c39dbf41d/pandas-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3b71f27954685ee685317063bf13c7709a7ba74fc996b84fc6821c59b0f06468", size = 12615650, upload-time = "2024-09-20T13:09:38.685Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8c/f0fd18f6140ddafc0c24122c8a964e48294acc579d47def376fef12bcb4a/pandas-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:38cf8125c40dae9d5acc10fa66af8ea6fdf760b2714ee482ca691fc66e6fcb18", size = 11290177, upload-time = "2024-09-20T13:09:41.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f9/e995754eab9c0f14c6777401f7eece0943840b7a9fc932221c19d1abee9f/pandas-2.2.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba96630bc17c875161df3818780af30e43be9b166ce51c9a18c1feae342906c2", size = 14651526, upload-time = "2024-09-20T19:02:16.905Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013, upload-time = "2024-09-20T13:09:44.39Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620, upload-time = "2024-09-20T19:02:20.639Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436, upload-time = "2024-09-20T13:09:48.112Z" },
+]
+
+[[package]]
+name = "patsy"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/81/74f6a65b848ffd16c18f920620ce999fe45fe27f01ab3911260ce4ed85e4/patsy-1.0.1.tar.gz", hash = "sha256:e786a9391eec818c054e359b737bbce692f051aee4c661f4141cc88fb459c0c4", size = 396010, upload-time = "2024-11-12T14:10:54.642Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/2b/b50d3d08ea0fc419c183a84210571eba005328efa62b6b98bc28e9ead32a/patsy-1.0.1-py2.py3-none-any.whl", hash = "sha256:751fb38f9e97e62312e921a1954b81e1bb2bcda4f5eeabaf94db251ee791509c", size = 232923, upload-time = "2024-11-12T14:10:52.85Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -199,6 +199,25 @@ const errorLogs = useWatchFetch(() => app.model.outputs.errorLogs, async (pframe
   return response.values.data.join('\n');
 });
 
+const excludedSamples = useWatchFetch(() => app.model.outputs.excludedSamples, async (pframeHandle) => {
+  if (!pframeHandle) {
+    return undefined;
+  }
+  const pFrame = new PFrameImpl(pframeHandle);
+  const list = await pFrame.listColumns();
+  if (!list || list.length === 0) {
+    return undefined;
+  }
+  // Find the reason column (the value column, not the axis)
+  const reasonCol = list.find((c) => c.spec.name === 'reason') ?? list[0];
+  const id = reasonCol.columnId;
+  const response = await pFrame.getUniqueValues({ columnId: id, filters: [], limit: 1000000 });
+  if (!response || response.values.data.length === 0) {
+    return undefined;
+  }
+  return [...(response.values.data as string[])].map((v) => String(v));
+});
+
 const defaultLabel = computed(() => deriveDefaultLabel(app.model.data));
 </script>
 
@@ -245,6 +264,15 @@ const defaultLabel = computed(() => deriveDefaultLabel(app.model.data));
         :required="true"
       />
       <PlDropdownMulti v-model="app.model.data.covariateRefs" :options="covariateOptions" label="Design" :required="true" />
+      <PlAlert v-if="excludedSamples.value !== undefined && excludedSamples.value.length > 0" type="warn" icon>
+        <template #default>
+          <strong>{{ excludedSamples.value.length }} sample(s) will be excluded from the analysis</strong>
+          because they have no abundance counts:
+          <ul style="margin: 4px 0 0 16px; padding: 0;">
+            <li v-for="(s, i) in excludedSamples.value" :key="i">{{ s }}</li>
+          </ul>
+        </template>
+      </PlAlert>
       <PlDropdown v-model="app.model.data.contrastFactor" :options="contrastFactorOptions" label="Contrast factor" :required="true" />
       <PlDropdownMulti v-model="app.model.data.numerators" :options="numeratorOptions.value" label="Numerator" :required="true" >
         <template #tooltip>

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -208,8 +208,10 @@ const excludedSamples = useWatchFetch(() => app.model.outputs.excludedSamples, a
   if (!list || list.length === 0) {
     return undefined;
   }
-  // Find the reason column (the value column, not the axis)
-  const reasonCol = list.find((c) => c.spec.name === 'reason') ?? list[0];
+  // Find the reason column by its columnId (the value column, not the axis).
+  // The PColumn's spec.name is the long pl7.app/... identifier; columnId
+  // matches the `id` field set in excluded-samples-conv.lib.tengo.
+  const reasonCol = list.find((c) => c.columnId === 'reason') ?? list[0];
   const id = reasonCol.columnId;
   const response = await pFrame.getUniqueValues({ columnId: id, filters: [], limit: 1000000 });
   if (!response || response.values.data.length === 0) {

--- a/workflow/src/diffAnalysis.tpl.tengo
+++ b/workflow/src/diffAnalysis.tpl.tengo
@@ -34,6 +34,7 @@ self.validateInputs({
 	continueOrNot: "any",
 	allCounts: "any",
 	csvCovariates: "any",
+	csvCounts: "any",
 	numerators: "any",
 	denominator: "any",
 	contrastFactor: "any",
@@ -111,8 +112,9 @@ self.body(func(inputs) {
 			label: traceLabel}
 		)
 
-		// convert PColumns to csv
-		csvCounts := xsv.exportFrame([inputs.allCounts], "csv", {mem: defaultConvMem, cpu: defaultConvCpu})
+		// main.tpl.tengo exports csvCounts upstream and passes it through inputs,
+		// so pre-checks and DESeq2 see the same data.
+		csvCounts := inputs.csvCounts
 
 		// Create PFrames for DEG, regulation direction and topTable
 		wf := pt.workflow().cpu(1).mem("2GiB")

--- a/workflow/src/excluded-samples-conv.lib.tengo
+++ b/workflow/src/excluded-samples-conv.lib.tengo
@@ -1,0 +1,41 @@
+ll := import("@platforma-sdk/workflow-tengo:ll")
+
+getColumns := func() {
+  return {
+    axes: [
+		{
+        column: "Sample",
+        allowNA: false,
+        spec: {
+            name: "pl7.app/sampleId",
+            type: "String",
+            domain: {},
+            annotations: {
+                "pl7.app/label": "Sample"
+            }
+        }
+      }
+      ],
+    columns: [
+		{
+            column: "reason",
+            id: "reason",
+            allowNA: true,
+            spec: {
+                name: "pl7.app/differentialAbundance/excludedReason",
+                valueType: "String",
+                domain: {},
+                annotations: {
+                    "pl7.app/label": "Reason"
+                }
+                }
+		}
+      ],
+    storageFormat: "Parquet",
+    partitionKeyLength: 0
+  }
+}
+
+export ll.toStrict({
+	getColumns: getColumns
+})

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -8,6 +8,7 @@ render := import("@platforma-sdk/workflow-tengo:render")
 ll := import("@platforma-sdk/workflow-tengo:ll")
 
 pfErrorLogsConv := import(":pf-de-errors-conv")
+excludedSamplesConv := import(":excluded-samples-conv")
 diffAnalysisTpl := assets.importTemplate(":diffAnalysis")
 
 wf.prepare(func(args){
@@ -65,18 +66,27 @@ wf.body(func(args) {
 	// convert PColumns to csv
 	csvCovariates := xsv.exportFrame(covariates, "csv", {mem: defaultConvMem, cpu: defaultConvCpu})
 
+	// Export counts to CSV once here; pass to both prev-checks and diffAnalysis
+	csvCounts := xsv.exportFrame([allCounts], "csv", {mem: defaultConvMem, cpu: defaultConvCpu})
+
 	// Run script to check if metadata matrix will be full rank
 	continueCheck := exec.builder().
 			software(assets.importSoftware("@platforma-open/milaboratories.run-diff-clonotype-abundance-deseq2-r.software:prev-checks")).
 			arg("--output").arg(".").
 			arg("--metadata").arg("covariates.csv").
 			addFile("covariates.csv", csvCovariates).
+			arg("--counts").arg("rawCounts.csv").
+			addFile("rawCounts.csv", csvCounts).
 			arg("--contrast_factor").arg(contrastFactor.spec.annotations["pl7.app/label"]).
 			arg("--numerators").arg(string(args.numerators)).
 			arg("--denominator").arg(denominator).
 			arg("--error_output").arg("./errorLogs.csv").
+			arg("--excluded_samples_output").arg("./excludedSamples.csv").
+			arg("--filtered_covariates_output").arg("./filteredCovariates.csv").
 			saveFileContent("continueOrNot.txt").
 			saveFile("errorLogs.csv").
+			saveFile("excludedSamples.csv").
+			saveFile("filteredCovariates.csv").
 			cache(24 * 60 * 60 * 1000).
 			run()
 
@@ -86,12 +96,18 @@ wf.body(func(args) {
 	errorLogsImportParams := pfErrorLogsConv.getColumns()
 	errorLogsPf := xsv.importFile(continueCheck.getFile("errorLogs.csv"), "csv", errorLogsImportParams, { mem: defaultConvMem, cpu: defaultConvCpu })
 
+	excludedSamplesImportParams := excludedSamplesConv.getColumns()
+	excludedSamplesPf := xsv.importFile(continueCheck.getFile("excludedSamples.csv"), "csv", excludedSamplesImportParams, { mem: defaultConvMem, cpu: defaultConvCpu })
+
+	filteredCovariates := continueCheck.getFile("filteredCovariates.csv")
+
 	// Run differential analysis template
 	// Analysis will only run if matrix is full rank (continueOrNot.txt content == "continue")
 	diffAnalysis := render.create(diffAnalysisTpl, {
 		continueOrNot: continueOrNot,
 		allCounts: allCounts,
-		csvCovariates: csvCovariates,
+		csvCovariates: filteredCovariates,
+		csvCounts: csvCounts,
 		numerators: args.numerators,
 		denominator: denominator,
 		contrastFactor: contrastFactor,
@@ -135,7 +151,8 @@ wf.body(func(args) {
 	return {
 		outputs: {
 			topTablePf: topDegPF,
-			errorLogs: pframes.exportFrame(errorLogsPf)
+			errorLogs: pframes.exportFrame(errorLogsPf),
+			excludedSamples: pframes.exportFrame(excludedSamplesPf)
 		},
 		exports: exports
 	}


### PR DESCRIPTION
## Summary

Fixes the crash when a Differential Abundance run includes a sample that produced no counts upstream. Previously DESeq2 tripped `ncol(countData) == nrow(colData) is not TRUE`; now the empty sample is excluded gracefully and the user sees a warning before the workflow finishes.

**Notion ticket:** MILAB-6366

## Layers

- **R (defense-in-depth):** both `clonotype_deseq2.R` and `gene_deseq2.R` now reconcile samples symmetrically. If the surviving group sizes fall below 2, the script stops with an actionable error rather than DESeq2's opaque stopifnot.
- **Python (pre-checks):** `prevChecks.py` now reads the counts CSV alongside metadata, writes a filtered covariates CSV consumed by downstream DESeq2, an `excludedSamples.csv` table, and per-sample warnings in `errorLogs.csv`. Short-circuits to \"stop\" when a contrast group falls below 2 replicates.
- **Tengo:** counts are exported once in `main.tpl.tengo` and threaded through to both pre-checks and `diffAnalysis` so they see identical data. New `excluded-samples-conv.lib.tengo` defines the PColumn schema for the excludedSamples output.
- **Model + UI:** new `excludedSamples` block-model output; `MainPage.vue` shows a dedicated `PlAlert` listing samples that will be excluded, between the Design and Contrast factor dropdowns.

## Tests

- **R smoke** (`software/tests/zero_sample_test.R`, runner `run_tests.sh`): four scenarios — clonotype drop (groups still ≥2), clonotype baseline (no false positives), group-too-small guard, gene-script drop. Skips cleanly if Rscript/DESeq2 not installed.
- **Python** (`software/tests/test_prev_checks.py`, uv + pytest, ruff-clean): ten scenarios covering reconciliation, multi-numerator group checks, rank deficiency, empty counts, schema stability, numeric sample IDs, and the new defensive output-dir creation.
- Wired into `pnpm -C software run test`.

## Test plan

- [ ] Reproduce the Notion ticket scenario locally: Peptide Profiling with the attached FASTQs + the documented pattern → DCA configured as in the screenshot.
- [ ] Confirm DCA no longer crashes; topTable populated for the two non-empty samples.
- [ ] Confirm the Settings modal shows the excluded-samples alert.
- [ ] Confirm the existing errorLogs banner also names the dropped sample.
- [ ] Re-run with only 2 samples (one A, one empty B): block stops cleanly with the new \"at least 2 are required\" message rather than DESeq2's stopifnot.
- [ ] Verify the changeset bumps workflow / software / model / ui / block at patch level.

## Out of scope

- Same structural bug exists in `blocks/differential-expression/software/src/deseq2/run_DESeq2.R`; separate ticket.
- Sample labels in the alert are raw sample IDs (may be hashes). Label resolution would need a separate UI iteration.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds graceful handling for samples that produce zero abundance counts upstream, fixing a crash where DESeq2 would trip `ncol(countData) == nrow(colData) is not TRUE`. The fix is layered across Python pre-checks, R scripts (defense-in-depth), Tengo workflow, model, and UI.

- **Python (`prevChecks.py`)**: reads counts alongside metadata, excludes zero-count samples, writes `filteredCovariates.csv` and `excludedSamples.csv`, and short-circuits to \"stop\" when a contrast group falls below 2 replicates after filtering.
- **R scripts (`clonotype_deseq2.R`, `gene_deseq2.R`)**: add symmetric sample reconciliation as a second layer, with an explicit group-size guard before DESeq2 runs.
- **Workflow + UI**: counts are exported once in `main.tpl.tengo` and threaded through; a new `excludedSamples` PFrame output surfaces in a `PlAlert` in the settings modal; 10 Python tests and 4 R smoke scenarios are added.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge with the column-lookup fix in MainPage.vue — without it, excluded-sample alerts may silently fail to render when there are dropped samples.

The Python and R logic is correct and well-tested. The Tengo workflow changes are clean and the filtered-covariates threading is consistent. The one concrete defect is in the Vue watcher: c.spec.name === 'reason' never matches the actual spec name 'pl7.app/differentialAbundance/excludedReason', so the column find always fails. The fallback to list[0] happens to work today because listColumns() appears to return value columns first, but this is fragile — if that ordering ever differs, excluded-sample warnings will silently disappear from the UI while the workflow correctly logs them.

ui/src/pages/MainPage.vue — the column-lookup logic in the excludedSamples watcher relies on a coincidental fallback and should be corrected before the feature can be considered reliable.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/pages/MainPage.vue | New excludedSamples watcher added; the column-lookup uses c.spec.name === 'reason' which never matches the actual spec name 'pl7.app/differentialAbundance/excludedReason' — fallback to list[0] likely works today based on the errorLogs pattern but is fragile. |
| software/src/prev-checks/prevChecks.py | Added --counts, --excluded_samples_output, and --filtered_covariates_output arguments; reads counts CSV to compute dropped samples, emits per-sample warnings, writes filtered covariates and excluded-samples CSVs; replicate check applied to filtered metadata only — logic is sound but skips silently when contrast_factor column is absent. |
| software/src/deseq2-clonotype/clonotype_deseq2.R | Added symmetric sample reconciliation and group-size guard before DESeq2 is invoked. Logic mirrors gene_deseq2.R exactly and is correct. |
| software/src/deseq2-gene/gene_deseq2.R | Identical reconciliation and group-size guard added as in clonotype_deseq2.R; both R scripts act as a correct defense-in-depth layer downstream of the Python pre-check. |
| workflow/src/main.tpl.tengo | Counts CSV exported once and passed to both prevChecks and diffAnalysis; filteredCovariates replaces raw covariates into diffAnalysis; new excludedSamples PFrame wired through to outputs — all changes are correct. |
| workflow/src/excluded-samples-conv.lib.tengo | New PColumn schema for excludedSamples output; schema fields are consistent with the platform pattern but file has inconsistent tab/space indentation. |
| model/src/index.ts | Added excludedSamples output block following the same PFrame pattern as existing errorLogs output — correct and minimal. |
| software/tests/test_prev_checks.py | Ten comprehensive pytest scenarios covering happy path, single/double drop, group-too-small, rank deficiency, empty counts, multi-numerators, schema stability, numeric IDs, and directory creation. |
| software/tests/zero_sample_test.R | Four R smoke-test scenarios covering drop-but-viable, baseline, group-too-small guard, and gene-script path; gracefully skips when DESeq2 is not installed. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant M as main.tpl.tengo
    participant PC as prevChecks.py
    participant DA as diffAnalysis.tpl.tengo
    participant R as clonotype/gene_deseq2.R
    participant UI as MainPage.vue

    M->>M: exportFrame(allCounts) to csvCounts
    M->>M: exportFrame(covariates) to csvCovariates
    M->>PC: csvCovariates, csvCounts, contrast params
    PC->>PC: "dropped = metadata_samples minus counts_samples"
    PC->>PC: write excludedSamples.csv
    PC->>PC: replicate check on filtered metadata
    alt insufficient replicates
        PC-->>M: "continueOrNot = stop"
    else full rank
        PC-->>M: "continueOrNot = continue"
    end
    PC-->>M: filteredCovariates.csv, errorLogs.csv, excludedSamples.csv
    M->>DA: continueOrNot, csvCounts, filteredCovariates
    DA->>R: rawCounts.csv (full), covariates.csv (filtered)
    R->>R: reconcile samples defense-in-depth
    R->>R: group-size guard
    R-->>DA: topTable.csv
    M-->>UI: errorLogs PFrame
    M-->>UI: excludedSamples PFrame
    UI->>UI: "render PlAlert if excludedSamples.length > 0"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
ui/src/pages/MainPage.vue:212-213
**Wrong property used in column lookup**

`c.spec.name` for the reason column is `'pl7.app/differentialAbundance/excludedReason'` (as defined in `excluded-samples-conv.lib.tengo`), not `'reason'`. The `.find()` therefore always returns `undefined` and the code silently falls through to `list[0]`. Based on the `errorLogs` pattern above (which uses `list?.[0].columnId` directly and works against a similarly structured PFrame), `list[0]` is probably the value column, so the behaviour may be accidentally correct today — but if `listColumns()` ever returns axes before value columns, `list[0]` would be the `Sample` axis entry, `columnId` would be undefined, and `getUniqueValues` would silently return nothing, hiding all excluded-sample alerts. The fix is to match on `columnId` rather than `spec.name`.

```suggestion
  // Find the reason column (the value column, not the axis)
  const reasonCol = list.find((c) => c.columnId === 'reason') ?? list[0];
```

### Issue 2 of 3
software/src/prev-checks/prevChecks.py:99-107
**Skipped replicate check when contrast factor column is absent**

If `args.contrast_factor` is not a column in the (possibly filtered) metadata — a misconfiguration that can happen when the label passed via `--contrast_factor` doesn't match any column header — the entire replicate-count loop is silently skipped (`insufficient` stays `False`) and the script proceeds to the rank check. In practice this results in a downstream "stop" via the rank-deficiency path rather than an actionable message naming the missing column. Adding an explicit check and error message here would surface the root cause immediately.

### Issue 3 of 3
workflow/src/excluded-samples-conv.lib.tengo:1-41
**Inconsistent indentation throughout the file**

The file mixes 2-space indentation (outer structure, closing brackets) with tabs (array element bodies), which differs from the style used in the sibling `pf-de-errors-conv` library. While Tengo is not whitespace-sensitive, the inconsistency makes the file harder to read and misaligns with the rest of the codebase's convention.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6366: gracefully handle samples wi..."](https://github.com/platforma-open/differential-clonotype-abundance/commit/94e7115971795d4181be0aee445cb1ad941030e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34391444)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->